### PR TITLE
Add Curve APY scheduler and API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Curve_ai_backend
+# Curve AI Backend
+
+This project provides a small service that periodically fetches Curve Finance pool
+metrics and stores them in a database. A REST API exposes the latest APY along with
+historical data for each pool.
+
+## Components
+
+- **Celery worker** (`apy.worker`): schedules a task every 8 hours to retrieve pool
+  metrics from the Curve API and store them in the `pool_metrics` table.
+- **FastAPI app** (`apy.api`): exposes `GET /pools/{pool_id}/apy` returning current
+  APY data plus 7-day and 30-day histories.
+
+## Development
+
+Install dependencies and run the API:
+
+```bash
+pip install -e .
+uvicorn apy.api:app --reload
+```
+
+Start the Celery worker with beat enabled:
+
+```bash
+celery -A apy.worker.celery_app worker --beat
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "curve-ai-backend"
+version = "0.1.0"
+description = "Curve APY backend"
+authors = [{name = "OpenAI"}]
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "requests",
+    "SQLAlchemy",
+    "celery",
+    "redis",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/apy/__init__.py
+++ b/src/apy/__init__.py
@@ -1,0 +1,6 @@
+"""APY package for Curve metrics."""
+
+from .api import app
+from .worker import celery_app
+
+__all__ = ["app", "celery_app"]

--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -1,0 +1,62 @@
+"""FastAPI application exposing pool APY endpoints."""
+
+from datetime import datetime, timedelta
+from fastapi import FastAPI, HTTPException
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal, PoolMetric, init_db
+
+app = FastAPI(title="Curve APY API")
+init_db()
+
+
+@app.get("/pools/{pool_id}/apy")
+def get_pool_apy(pool_id: str):
+    """Return current APY and historical metrics for the given pool."""
+    session: Session = SessionLocal()
+    try:
+        latest = (
+            session.query(PoolMetric)
+            .filter(PoolMetric.pool_id == pool_id)
+            .order_by(PoolMetric.recorded_at.desc())
+            .first()
+        )
+        if not latest:
+            raise HTTPException(status_code=404, detail="Pool not found")
+
+        now = datetime.utcnow()
+        seven_days = now - timedelta(days=7)
+        thirty_days = now - timedelta(days=30)
+
+        history7 = (
+            session.query(PoolMetric)
+            .filter(PoolMetric.pool_id == pool_id, PoolMetric.recorded_at >= seven_days)
+            .order_by(PoolMetric.recorded_at)
+            .all()
+        )
+        history30 = (
+            session.query(PoolMetric)
+            .filter(PoolMetric.pool_id == pool_id, PoolMetric.recorded_at >= thirty_days)
+            .order_by(PoolMetric.recorded_at)
+            .all()
+        )
+
+        def serialize(metric: PoolMetric):
+            return {
+                "apy": metric.apy,
+                "bribe": metric.bribe,
+                "trading_fee": metric.trading_fee,
+                "crv": metric.crv,
+                "recorded_at": metric.recorded_at.isoformat(),
+            }
+
+        return {
+            "pool_id": pool_id,
+            "current": serialize(latest),
+            "history": {
+                "7d": [serialize(m) for m in history7],
+                "30d": [serialize(m) for m in history30],
+            },
+        }
+    finally:
+        session.close()

--- a/src/apy/curve.py
+++ b/src/apy/curve.py
@@ -1,0 +1,51 @@
+"""Client helpers for retrieving Curve pool data."""
+
+from typing import List, Dict
+import requests
+
+CURVE_API = "https://api.curve.fi/api/getPools/ethereum/main"
+
+
+def fetch_pool_data() -> List[Dict[str, float]]:
+    """Fetch pool metrics from the Curve API.
+
+    The structure of the Curve API may change; this function attempts to extract
+    common fields such as APY, bribe rewards, trading fee and CRV rewards.
+    Missing fields are filled with ``0``.
+    """
+    try:
+        response = requests.get(CURVE_API, timeout=10)
+        response.raise_for_status()
+        data = response.json().get("data", {}).get("poolData", [])
+    except Exception:
+        # In case of network or parsing errors return empty result to avoid
+        # crashing the scheduler.
+        return []
+
+    pools: List[Dict[str, float]] = []
+    for pool in data:
+        pool_id = pool.get("id") or pool.get("address")
+        apy = 0.0
+        apy_data = pool.get("apy") or pool.get("apyFormatted")
+        if isinstance(apy_data, dict):
+            apy = apy_data.get("total") or apy_data.get("apy", 0.0)
+        elif isinstance(apy_data, (int, float)):
+            apy = float(apy_data)
+        bribe = pool.get("bribeApy") or 0.0
+        trading_fee = pool.get("tradingFee") or pool.get("fee") or 0.0
+        crv = 0.0
+        for reward in pool.get("gaugeRewards", []) or []:
+            token = reward.get("token", "").lower()
+            if token == "crv":
+                crv = reward.get("apy", 0.0)
+                break
+        pools.append(
+            {
+                "pool_id": pool_id,
+                "apy": apy,
+                "bribe": bribe,
+                "trading_fee": trading_fee,
+                "crv": crv,
+            }
+        )
+    return pools

--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -1,0 +1,31 @@
+"""Database setup for storing pool metrics."""
+
+import os
+from datetime import datetime
+from sqlalchemy import create_engine, Column, Integer, Float, String, DateTime
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///curve.db")
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base = declarative_base()
+
+
+class PoolMetric(Base):
+    """SQLAlchemy model for a snapshot of pool metrics."""
+
+    __tablename__ = "pool_metrics"
+
+    id = Column(Integer, primary_key=True, index=True)
+    pool_id = Column(String, index=True, nullable=False)
+    apy = Column(Float)
+    bribe = Column(Float)
+    trading_fee = Column(Float)
+    crv = Column(Float)
+    recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+def init_db() -> None:
+    """Create database tables if they do not exist."""
+    Base.metadata.create_all(bind=engine)

--- a/src/apy/tasks.py
+++ b/src/apy/tasks.py
@@ -1,0 +1,37 @@
+"""Celery tasks for fetching and storing Curve pool metrics."""
+
+from datetime import datetime
+from typing import List, Dict
+
+from .worker import celery_app
+from .curve import fetch_pool_data
+from .database import SessionLocal, PoolMetric
+
+
+@celery_app.task
+def fetch_all_pool_metrics() -> int:
+    """Fetch metrics for all pools and store them in the database.
+
+    Returns the number of records inserted.
+    """
+    pool_metrics: List[Dict[str, float]] = fetch_pool_data()
+    session = SessionLocal()
+    try:
+        count = 0
+        now = datetime.utcnow()
+        for metric in pool_metrics:
+            session.add(
+                PoolMetric(
+                    pool_id=metric["pool_id"],
+                    apy=metric.get("apy"),
+                    bribe=metric.get("bribe"),
+                    trading_fee=metric.get("trading_fee"),
+                    crv=metric.get("crv"),
+                    recorded_at=now,
+                )
+            )
+            count += 1
+        session.commit()
+        return count
+    finally:
+        session.close()

--- a/src/apy/worker.py
+++ b/src/apy/worker.py
@@ -1,0 +1,18 @@
+"""Celery application with a periodic task to update pool metrics."""
+
+from celery import Celery
+
+celery_app = Celery(
+    "apy",
+    broker="redis://localhost:6379/0",
+    backend="redis://localhost:6379/0",
+)
+
+celery_app.conf.beat_schedule = {
+    "fetch-pool-metrics": {
+        "task": "apy.tasks.fetch_all_pool_metrics",
+        # every 8 hours
+        "schedule": 60 * 60 * 8,
+    }
+}
+celery_app.conf.timezone = "UTC"


### PR DESCRIPTION
## Summary
- add Celery app scheduled every 8h to fetch Curve pool metrics
- parse APY, bribe, trading fee, and CRV data and store snapshots
- expose FastAPI endpoint to retrieve current and historical APY data

## Testing
- `pip install fastapi uvicorn requests SQLAlchemy celery redis`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890eed81ec48324816b82bcd86e812f