### PR TITLE
Expose yield sources and store components separately

### DIFF
--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -1,62 +1,134 @@
-"""FastAPI application exposing pool APY endpoints."""
+"""FastAPI application exposing pool APY and yield source endpoints."""
 
 from datetime import datetime, timedelta
+from typing import Dict, List
+
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from .database import SessionLocal, PoolMetric, init_db
+
 
 app = FastAPI(title="Curve APY API")
 init_db()
 
 
-@app.get("/pools/{pool_id}/apy")
+class YieldComponent(BaseModel):
+    """Breakdown of APY sources for a snapshot."""
+
+    bribe: float = Field(0.0, description="Bribe APY component")
+    trading_fee: float = Field(0.0, description="Trading fee APY component")
+    crv_reward: float = Field(0.0, description="CRV reward APY component")
+    recorded_at: datetime
+
+
+class APYSnapshot(YieldComponent):
+    """A snapshot including the total APY."""
+
+    apy: float = Field(0.0, description="Total APY")
+
+
+class APYHistoryResponse(BaseModel):
+    """Response schema for APY metrics including history."""
+
+    pool_id: str
+    current: APYSnapshot
+    history: Dict[str, List[APYSnapshot]]
+
+
+class YieldSourcesResponse(BaseModel):
+    """Response schema for yield source breakdown."""
+
+    pool_id: str
+    current: YieldComponent
+    history: Dict[str, List[YieldComponent]]
+
+
+def _get_metrics(session: Session, pool_id: str):
+    """Retrieve latest metric and 7/30 day histories for a pool."""
+
+    latest = (
+        session.query(PoolMetric)
+        .filter(PoolMetric.pool_id == pool_id)
+        .order_by(PoolMetric.recorded_at.desc())
+        .first()
+    )
+    if not latest:
+        raise HTTPException(status_code=404, detail="Pool not found")
+
+    now = datetime.utcnow()
+    seven_days = now - timedelta(days=7)
+    thirty_days = now - timedelta(days=30)
+
+    history7 = (
+        session.query(PoolMetric)
+        .filter(PoolMetric.pool_id == pool_id, PoolMetric.recorded_at >= seven_days)
+        .order_by(PoolMetric.recorded_at)
+        .all()
+    )
+    history30 = (
+        session.query(PoolMetric)
+        .filter(PoolMetric.pool_id == pool_id, PoolMetric.recorded_at >= thirty_days)
+        .order_by(PoolMetric.recorded_at)
+        .all()
+    )
+    return latest, history7, history30
+
+
+@app.get("/pools/{pool_id}/apy", response_model=APYHistoryResponse)
 def get_pool_apy(pool_id: str):
     """Return current APY and historical metrics for the given pool."""
+
     session: Session = SessionLocal()
     try:
-        latest = (
-            session.query(PoolMetric)
-            .filter(PoolMetric.pool_id == pool_id)
-            .order_by(PoolMetric.recorded_at.desc())
-            .first()
-        )
-        if not latest:
-            raise HTTPException(status_code=404, detail="Pool not found")
+        latest, history7, history30 = _get_metrics(session, pool_id)
 
-        now = datetime.utcnow()
-        seven_days = now - timedelta(days=7)
-        thirty_days = now - timedelta(days=30)
+        def serialize(metric: PoolMetric) -> APYSnapshot:
+            return APYSnapshot(
+                apy=metric.apy,
+                bribe=metric.bribe,
+                trading_fee=metric.trading_fee,
+                crv_reward=metric.crv_reward,
+                recorded_at=metric.recorded_at,
+            )
 
-        history7 = (
-            session.query(PoolMetric)
-            .filter(PoolMetric.pool_id == pool_id, PoolMetric.recorded_at >= seven_days)
-            .order_by(PoolMetric.recorded_at)
-            .all()
-        )
-        history30 = (
-            session.query(PoolMetric)
-            .filter(PoolMetric.pool_id == pool_id, PoolMetric.recorded_at >= thirty_days)
-            .order_by(PoolMetric.recorded_at)
-            .all()
-        )
-
-        def serialize(metric: PoolMetric):
-            return {
-                "apy": metric.apy,
-                "bribe": metric.bribe,
-                "trading_fee": metric.trading_fee,
-                "crv": metric.crv,
-                "recorded_at": metric.recorded_at.isoformat(),
-            }
-
-        return {
-            "pool_id": pool_id,
-            "current": serialize(latest),
-            "history": {
+        return APYHistoryResponse(
+            pool_id=pool_id,
+            current=serialize(latest),
+            history={
                 "7d": [serialize(m) for m in history7],
                 "30d": [serialize(m) for m in history30],
             },
-        }
+        )
     finally:
         session.close()
+
+
+@app.get("/pools/{pool_id}/yield-sources", response_model=YieldSourcesResponse)
+def get_yield_sources(pool_id: str):
+    """Return bribe, trading fee and CRV reward components for a pool."""
+
+    session: Session = SessionLocal()
+    try:
+        latest, history7, history30 = _get_metrics(session, pool_id)
+
+        def serialize(metric: PoolMetric) -> YieldComponent:
+            return YieldComponent(
+                bribe=metric.bribe,
+                trading_fee=metric.trading_fee,
+                crv_reward=metric.crv_reward,
+                recorded_at=metric.recorded_at,
+            )
+
+        return YieldSourcesResponse(
+            pool_id=pool_id,
+            current=serialize(latest),
+            history={
+                "7d": [serialize(m) for m in history7],
+                "30d": [serialize(m) for m in history30],
+            },
+        )
+    finally:
+        session.close()
+

--- a/src/apy/curve.py
+++ b/src/apy/curve.py
@@ -33,11 +33,11 @@ def fetch_pool_data() -> List[Dict[str, float]]:
             apy = float(apy_data)
         bribe = pool.get("bribeApy") or 0.0
         trading_fee = pool.get("tradingFee") or pool.get("fee") or 0.0
-        crv = 0.0
+        crv_reward = 0.0
         for reward in pool.get("gaugeRewards", []) or []:
             token = reward.get("token", "").lower()
             if token == "crv":
-                crv = reward.get("apy", 0.0)
+                crv_reward = reward.get("apy", 0.0)
                 break
         pools.append(
             {
@@ -45,7 +45,7 @@ def fetch_pool_data() -> List[Dict[str, float]]:
                 "apy": apy,
                 "bribe": bribe,
                 "trading_fee": trading_fee,
-                "crv": crv,
+                "crv_reward": crv_reward,
             }
         )
     return pools

--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -22,7 +22,7 @@ class PoolMetric(Base):
     apy = Column(Float)
     bribe = Column(Float)
     trading_fee = Column(Float)
-    crv = Column(Float)
+    crv_reward = Column(Float)
     recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 

--- a/src/apy/tasks.py
+++ b/src/apy/tasks.py
@@ -26,7 +26,7 @@ def fetch_all_pool_metrics() -> int:
                     apy=metric.get("apy"),
                     bribe=metric.get("bribe"),
                     trading_fee=metric.get("trading_fee"),
-                    crv=metric.get("crv"),
+                    crv_reward=metric.get("crv_reward"),
                     recorded_at=now,
                 )
             )


### PR DESCRIPTION
## Summary
- store bribe, trading_fee, and CRV reward per snapshot
- add GET /pools/{pool_id}/yield-sources endpoint with OpenAPI docs
- document responses using pydantic models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f19ed89883248d9135b81b503a0a