### PR TITLE
Add user earnings endpoint

### DIFF
--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -2,9 +2,11 @@
 
 from datetime import datetime, timedelta
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from .database import SessionLocal, PoolMetric, init_db
+from .services import calculate_total_earning
 
 app = FastAPI(title="Curve APY API")
 init_db()
@@ -60,3 +62,14 @@ def get_pool_apy(pool_id: str):
         }
     finally:
         session.close()
+
+
+class EarningsRequest(BaseModel):
+    pool_id: str
+    amount: float
+
+
+@app.post("/users/{user_id}/earnings")
+def post_user_earnings(user_id: str, payload: EarningsRequest):
+    """Record a user's deposit and return projected earnings."""
+    return calculate_total_earning(user_id, payload.pool_id, payload.amount)

--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -26,6 +26,17 @@ class PoolMetric(Base):
     recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+class UserPosition(Base):
+    """Track per-user deposits into pools."""
+
+    __tablename__ = "user_positions"
+
+    user_id = Column(String, primary_key=True)
+    pool_id = Column(String, primary_key=True)
+    amount = Column(Float, default=0.0)
+    last_updated = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
 def init_db() -> None:
     """Create database tables if they do not exist."""
     Base.metadata.create_all(bind=engine)

--- a/src/apy/services.py
+++ b/src/apy/services.py
@@ -1,0 +1,81 @@
+"""Service layer for user earnings calculations."""
+
+from datetime import datetime
+from typing import Dict
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal, PoolMetric, UserPosition
+
+
+def calculate_total_earning(user_id: str, pool_id: str, amount: float) -> Dict[str, float]:
+    """Update user deposit and calculate projected earnings.
+
+    Parameters
+    ----------
+    user_id: str
+        Identifier of the user.
+    pool_id: str
+        Identifier of the pool being deposited to.
+    amount: float
+        Amount the user is depositing.
+
+    Returns
+    -------
+    dict
+        Dictionary containing total_amount, projected_earning and current_apr.
+    """
+    session: Session = SessionLocal()
+    try:
+        # Update or create the user's position
+        position = (
+            session.query(UserPosition)
+            .filter(
+                UserPosition.user_id == user_id,
+                UserPosition.pool_id == pool_id,
+            )
+            .first()
+        )
+        now = datetime.utcnow()
+        if position:
+            position.amount += amount
+            position.last_updated = now
+        else:
+            position = UserPosition(
+                user_id=user_id,
+                pool_id=pool_id,
+                amount=amount,
+                last_updated=now,
+            )
+            session.add(position)
+        session.commit()
+
+        total_amount = position.amount
+
+        # Historical APY: average across all records for the pool
+        avg_apy = (
+            session.query(func.avg(PoolMetric.apy))
+            .filter(PoolMetric.pool_id == pool_id)
+            .scalar()
+        ) or 0.0
+        projected_earning = total_amount * (avg_apy / 100)
+
+        # Current APR from latest snapshot
+        latest = (
+            session.query(PoolMetric)
+            .filter(PoolMetric.pool_id == pool_id)
+            .order_by(PoolMetric.recorded_at.desc())
+            .first()
+        )
+        current_apr = latest.apy if latest and latest.apy is not None else 0.0
+
+        return {
+            "user_id": user_id,
+            "pool_id": pool_id,
+            "total_amount": total_amount,
+            "projected_earning": projected_earning,
+            "current_apr": current_apr,
+        }
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- track user deposits with new `user_positions` table
- compute projected earnings from historical APY data
- expose endpoint to record deposits and return projected earnings

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890f19762708324a1fd05f8ebae9790