### PR TITLE
Add deposit transaction tracking and endpoints

### DIFF
--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -37,6 +37,24 @@ class UserPosition(Base):
     last_updated = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
+class DepositTransaction(Base):
+    """Record on-chain deposit transactions for a user."""
+
+    __tablename__ = "deposit_transactions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(String, index=True, nullable=False)
+    amount = Column(Float, nullable=False)
+    asset = Column(String, nullable=False)
+    from_address = Column(String, nullable=False)
+    network = Column(String, nullable=False)
+    gas_fee = Column(Float, default=0.0)
+    net_received = Column(Float, nullable=False)
+    status = Column(String, default="pending")
+    tx_hash = Column(String, unique=True, index=True, nullable=False)
+    recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
 def init_db() -> None:
     """Create database tables if they do not exist."""
     Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- add `DepositTransaction` model for recording user deposits
- provide CRUD services and pagination helpers for deposit transactions
- expose `/users/{user_id}/deposits` POST and GET endpoints with Pydantic schemas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f9d6ad9c8324b6186d1a3f35eaa2