### PR TITLE
feat: add rebalance tracking

### DIFF
--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -16,6 +16,7 @@ from .services import (
     get_deposit_transactions,
     create_withdrawal_transaction,
     get_withdrawal_transactions,
+    get_rebalance_actions,
 )
 
 
@@ -114,6 +115,34 @@ class WithdrawalListResponse(BaseModel):
 
     total: int
     items: List[WithdrawalResponse]
+
+
+class RebalanceActionResponse(BaseModel):
+    """Serialized rebalance action."""
+
+    id: int
+    user_id: str
+    old_pool: str
+    new_pool: str
+    old_apy: float
+    new_apy: float
+    strategy: str
+    action_type: str
+    moved_amount: float
+    asset_type: str
+    new_allocation: float
+    gas_cost: float
+    executed_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class RebalanceListResponse(BaseModel):
+    """Paginated list of rebalance actions."""
+
+    total: int
+    items: List[RebalanceActionResponse]
 
 
 class EarningsRequest(BaseModel):
@@ -259,6 +288,14 @@ def get_user_withdrawals(user_id: str, skip: int = 0, limit: int = 10):
 
     records, total = get_withdrawal_transactions(user_id, skip, limit)
     return WithdrawalListResponse(total=total, items=records)
+
+
+@app.get("/users/{user_id}/rebalances", response_model=RebalanceListResponse)
+def get_user_rebalances(user_id: str, skip: int = 0, limit: int = 10):
+    """Return paginated rebalance actions for the user."""
+
+    records, total = get_rebalance_actions(user_id, skip, limit)
+    return RebalanceListResponse(total=total, items=records)
 
 
 @app.post("/users/{user_id}/earnings")

--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -73,6 +73,26 @@ class WithdrawalTransaction(Base):
     recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+class RebalanceAction(Base):
+    """Record strategy-driven rebalance actions for a user."""
+
+    __tablename__ = "rebalance_actions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(String, index=True, nullable=False)
+    old_pool = Column(String, nullable=False)
+    new_pool = Column(String, nullable=False)
+    old_apy = Column(Float, nullable=False)
+    new_apy = Column(Float, nullable=False)
+    strategy = Column(String, nullable=False)
+    action_type = Column(String, nullable=False)
+    moved_amount = Column(Float, nullable=False)
+    asset_type = Column(String, nullable=False)
+    new_allocation = Column(Float, nullable=False)
+    gas_cost = Column(Float, default=0.0)
+    executed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
 def init_db() -> None:
     """Create database tables if they do not exist."""
     Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- store rebalance activity via new RebalanceAction ORM model
- support recording and querying rebalance actions in the service layer
- expose `/users/{user_id}/rebalances` endpoint with structured response models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689101eab994832482b00e16c51ee476