### PR TITLE
Add fund deployment tracking and API endpoint

### DIFF
--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -17,6 +17,7 @@ from .services import (
     create_withdrawal_transaction,
     get_withdrawal_transactions,
     get_rebalance_actions,
+    get_fund_deployments,
 )
 
 
@@ -143,6 +144,29 @@ class RebalanceListResponse(BaseModel):
 
     total: int
     items: List[RebalanceActionResponse]
+
+
+class DeploymentResponse(BaseModel):
+    """Serialized fund deployment."""
+
+    id: int
+    user_id: str
+    strategy: str
+    risk_level: str
+    expected_apy: float
+    tx_fee: float
+    status: str
+    executed_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class DeploymentListResponse(BaseModel):
+    """Paginated list of fund deployments."""
+
+    total: int
+    items: List[DeploymentResponse]
 
 
 class EarningsRequest(BaseModel):
@@ -288,6 +312,28 @@ def get_user_withdrawals(user_id: str, skip: int = 0, limit: int = 10):
 
     records, total = get_withdrawal_transactions(user_id, skip, limit)
     return WithdrawalListResponse(total=total, items=records)
+
+
+@app.get("/users/{user_id}/deployments", response_model=DeploymentListResponse)
+def get_user_deployments(
+    user_id: str,
+    skip: int = 0,
+    limit: int = 10,
+    status: str | None = None,
+    strategy: str | None = None,
+    risk_level: str | None = None,
+):
+    """Return paginated fund deployments for the user with optional filters."""
+
+    records, total = get_fund_deployments(
+        user_id,
+        skip=skip,
+        limit=limit,
+        status=status,
+        strategy=strategy,
+        risk_level=risk_level,
+    )
+    return DeploymentListResponse(total=total, items=records)
 
 
 @app.get("/users/{user_id}/rebalances", response_model=RebalanceListResponse)

--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -93,6 +93,21 @@ class RebalanceAction(Base):
     executed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+class FundDeployment(Base):
+    """Record fund deployments initiated for a user."""
+
+    __tablename__ = "fund_deployments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(String, index=True, nullable=False)
+    strategy = Column(String, nullable=False)
+    risk_level = Column(String, nullable=False)
+    expected_apy = Column(Float, nullable=False)
+    tx_fee = Column(Float, default=0.0)
+    status = Column(String, default="pending")
+    executed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
 def init_db() -> None:
     """Create database tables if they do not exist."""
     Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- add FundDeployment model for tracking deployment metadata
- log deployments and retrieve with pagination and filters
- expose GET /users/{user_id}/deployments endpoint with response models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891062733808324ac43a75edada8c13