### PR TITLE
Add risk adjustment tracking

### DIFF
--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -18,6 +18,7 @@ from .services import (
     get_withdrawal_transactions,
     get_rebalance_actions,
     get_fund_deployments,
+    get_risk_adjustments,
 )
 
 
@@ -144,6 +145,45 @@ class RebalanceListResponse(BaseModel):
 
     total: int
     items: List[RebalanceActionResponse]
+
+
+class RiskAdjustmentRequest(BaseModel):
+    """Request body for recording a risk adjustment."""
+
+    pool_id: str
+    total_volatility: float
+    trigger_event: str
+    action_taken: str
+    reallocated_amount: float
+    asset_type: str
+    old_risk_score: float
+    new_risk_score: float
+
+
+class RiskAdjustmentResponse(BaseModel):
+    """Serialized risk adjustment record."""
+
+    id: int
+    user_id: str
+    pool_id: str
+    total_volatility: float
+    trigger_event: str
+    action_taken: str
+    reallocated_amount: float
+    asset_type: str
+    old_risk_score: float
+    new_risk_score: float
+    recorded_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class RiskAdjustmentListResponse(BaseModel):
+    """Paginated list of risk adjustments."""
+
+    total: int
+    items: List[RiskAdjustmentResponse]
 
 
 class DeploymentResponse(BaseModel):
@@ -342,6 +382,14 @@ def get_user_rebalances(user_id: str, skip: int = 0, limit: int = 10):
 
     records, total = get_rebalance_actions(user_id, skip, limit)
     return RebalanceListResponse(total=total, items=records)
+
+
+@app.get("/users/{user_id}/risk-adjustments", response_model=RiskAdjustmentListResponse)
+def get_user_risk_adjustments(user_id: str, skip: int = 0, limit: int = 10):
+    """Return paginated risk adjustment records for the user."""
+
+    records, total = get_risk_adjustments(user_id, skip, limit)
+    return RiskAdjustmentListResponse(total=total, items=records)
 
 
 @app.post("/users/{user_id}/earnings")

--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -108,6 +108,24 @@ class FundDeployment(Base):
     executed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+class RiskAdjustment(Base):
+    """Record risk-based reallocation adjustments for a user."""
+
+    __tablename__ = "risk_adjustments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(String, index=True, nullable=False)
+    pool_id = Column(String, index=True, nullable=False)
+    total_volatility = Column(Float, nullable=False)
+    trigger_event = Column(String, nullable=False)
+    action_taken = Column(String, nullable=False)
+    reallocated_amount = Column(Float, nullable=False)
+    asset_type = Column(String, nullable=False)
+    old_risk_score = Column(Float, nullable=False)
+    new_risk_score = Column(Float, nullable=False)
+    recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
 def init_db() -> None:
     """Create database tables if they do not exist."""
     Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- model RiskAdjustment to persist user risk reallocation events
- service helpers to record and page through risk adjustments
- endpoint to list user risk adjustments with request/response schemas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910b0a673883249e68428879dfc367