### PR TITLE
feat: add user action creation endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 This project provides a small service that periodically fetches Curve Finance pool
 metrics and stores them in a database. A REST API exposes the latest APY along with
-historical data for each pool.
+historical data for each pool and supports recording user actions.
 
 ## Components
 
 - **Celery worker** (`apy.worker`): schedules a task every 8 hours to retrieve pool
   metrics from the Curve API and store them in the `pool_metrics` table.
 - **FastAPI app** (`apy.api`): exposes `GET /pools/{pool_id}/apy` returning current
-  APY data plus 7-day and 30-day histories.
+  APY data plus 7-day and 30-day histories, and endpoints for recording deposits,
+  withdrawals, rebalances, fund deployments and risk adjustments.
 - **Curve API wrapper** (`apy.curve`): helper client that normalizes data from the
   public Curve Finance API.
 
@@ -29,6 +30,17 @@ for pool in fetch_pool_data():
 
 Each item in the returned list contains the pool identifier along with its APY,
 bribe, trading fee and CRV reward components.
+
+## User Action Endpoints
+
+The API also allows tracking of user operations:
+
+- `POST /users/{user_id}/rebalances` – record a strategy-driven rebalance action.
+- `POST /users/{user_id}/deployments` – store a new fund deployment.
+- `POST /users/{user_id}/risk-adjustments` – log a risk-based reallocation.
+
+Each endpoint accepts a JSON payload describing the event and returns the stored
+record.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add Pydantic request models for rebalance actions and fund deployments
- expose POST endpoints for deployments, rebalances and risk adjustments
- document user action APIs in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689114b4d4e483248b842ab0387aaae1