### PR TITLE
Add user position endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ The API also allows tracking of user operations:
 - `POST /users/{user_id}/rebalances` – record a strategy-driven rebalance action.
 - `POST /users/{user_id}/deployments` – store a new fund deployment.
 - `POST /users/{user_id}/risk-adjustments` – log a risk-based reallocation.
+- `GET /users/{user_id}/positions` – retrieve current positions with projected earnings.
+- `POST /users/{user_id}/earnings` – submit a deposit and calculate updated earnings.
+
+### Querying positions and calculating earnings
+
+After making deposits with the earnings endpoint, aggregated holdings and projected
+returns can be fetched:
+
+```bash
+curl http://localhost:8000/users/alice/positions
+```
+
+The response includes per-pool amounts, projected earnings, current APR and totals
+across all pools.
 
 Each endpoint accepts a JSON payload describing the event and returns the stored
 record.

--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from .database import SessionLocal, PoolMetric, init_db
 from .services import (
     calculate_total_earning,
+    get_user_positions,
     create_deposit_transaction,
     get_deposit_transactions,
     create_withdrawal_transaction,
@@ -237,6 +238,24 @@ class DeploymentListResponse(BaseModel):
     items: List[DeploymentResponse]
 
 
+class UserPositionItem(BaseModel):
+    """Representation of a user's holdings in a pool."""
+
+    pool_id: str
+    amount: float
+    projected_earning: float
+    current_apr: float
+
+
+class UserPositionsResponse(BaseModel):
+    """Aggregated response for all user positions."""
+
+    user_id: str
+    total_amount: float
+    total_projected_earning: float
+    positions: List[UserPositionItem]
+
+
 class EarningsRequest(BaseModel):
     """Request body for calculating earnings for a deposit."""
 
@@ -416,6 +435,13 @@ def get_user_deployments(
         risk_level=risk_level,
     )
     return DeploymentListResponse(total=total, items=records)
+
+
+@app.get("/users/{user_id}/positions", response_model=UserPositionsResponse)
+def get_user_positions_endpoint(user_id: str) -> UserPositionsResponse:
+    """Return aggregated positions and earnings for the user."""
+
+    return get_user_positions(user_id)
 
 
 @app.post("/users/{user_id}/rebalances", response_model=RebalanceActionResponse)


### PR DESCRIPTION
## Summary
- add service layer aggregation for user positions with earnings
- expose `GET /users/{user_id}/positions` endpoint returning positions and totals
- document how to query positions and earnings

## Testing
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689115d7cde4832499dd4216105ed951