### PR TITLE
feat: add token auth for user routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ The API also allows tracking of user operations:
 - `GET /users/{user_id}/positions` – retrieve current positions with projected earnings.
 - `POST /users/{user_id}/earnings` – submit a deposit and calculate updated earnings.
 
+### Authentication
+
+All `/users/{user_id}/*` endpoints require a bearer token. Tokens are configured
+via the `API_TOKENS` environment variable using comma-separated `user:token`
+pairs:
+
+```bash
+export API_TOKENS="alice:alice-token,bob:bob-token"
+```
+
+Include the token in requests using the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer alice-token" \
+     http://localhost:8000/users/alice/positions
+```
+
+Using a token for a different user or an unknown token returns an authentication
+error.
+
 ### Querying positions and calculating earnings
 
 After making deposits with the earnings endpoint, aggregated holdings and projected

--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -3,12 +3,13 @@
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 
 from pydantic import BaseModel, Field
 
 from sqlalchemy.orm import Session
 
+from .auth import verify_user
 from .database import SessionLocal, PoolMetric, init_db
 from .services import (
     calculate_total_earning,
@@ -351,7 +352,11 @@ def get_yield_sources(pool_id: str):
         session.close()
 
 
-@app.post("/users/{user_id}/deposits", response_model=DepositResponse)
+@app.post(
+    "/users/{user_id}/deposits",
+    response_model=DepositResponse,
+    dependencies=[Depends(verify_user)],
+)
 def post_user_deposit(user_id: str, payload: DepositRequest):
     """Record a new deposit transaction for the user."""
 
@@ -368,7 +373,11 @@ def post_user_deposit(user_id: str, payload: DepositRequest):
     )
 
 
-@app.get("/users/{user_id}/deposits", response_model=DepositListResponse)
+@app.get(
+    "/users/{user_id}/deposits",
+    response_model=DepositListResponse,
+    dependencies=[Depends(verify_user)],
+)
 def get_user_deposits(user_id: str, skip: int = 0, limit: int = 10):
     """Return paginated deposit transactions for the user."""
 
@@ -376,7 +385,11 @@ def get_user_deposits(user_id: str, skip: int = 0, limit: int = 10):
     return DepositListResponse(total=total, items=records)
 
 
-@app.post("/users/{user_id}/withdrawals", response_model=WithdrawalResponse)
+@app.post(
+    "/users/{user_id}/withdrawals",
+    response_model=WithdrawalResponse,
+    dependencies=[Depends(verify_user)],
+)
 def post_user_withdrawal(user_id: str, payload: WithdrawalRequest):
     """Record a new withdrawal transaction for the user."""
 
@@ -393,7 +406,11 @@ def post_user_withdrawal(user_id: str, payload: WithdrawalRequest):
     )
 
 
-@app.get("/users/{user_id}/withdrawals", response_model=WithdrawalListResponse)
+@app.get(
+    "/users/{user_id}/withdrawals",
+    response_model=WithdrawalListResponse,
+    dependencies=[Depends(verify_user)],
+)
 def get_user_withdrawals(user_id: str, skip: int = 0, limit: int = 10):
     """Return paginated withdrawal transactions for the user."""
 
@@ -401,7 +418,11 @@ def get_user_withdrawals(user_id: str, skip: int = 0, limit: int = 10):
     return WithdrawalListResponse(total=total, items=records)
 
 
-@app.post("/users/{user_id}/deployments", response_model=DeploymentResponse)
+@app.post(
+    "/users/{user_id}/deployments",
+    response_model=DeploymentResponse,
+    dependencies=[Depends(verify_user)],
+)
 def post_user_deployment(user_id: str, payload: DeploymentRequest):
     """Record a new fund deployment for the user."""
 
@@ -415,7 +436,11 @@ def post_user_deployment(user_id: str, payload: DeploymentRequest):
     )
 
 
-@app.get("/users/{user_id}/deployments", response_model=DeploymentListResponse)
+@app.get(
+    "/users/{user_id}/deployments",
+    response_model=DeploymentListResponse,
+    dependencies=[Depends(verify_user)],
+)
 def get_user_deployments(
     user_id: str,
     skip: int = 0,
@@ -437,14 +462,22 @@ def get_user_deployments(
     return DeploymentListResponse(total=total, items=records)
 
 
-@app.get("/users/{user_id}/positions", response_model=UserPositionsResponse)
+@app.get(
+    "/users/{user_id}/positions",
+    response_model=UserPositionsResponse,
+    dependencies=[Depends(verify_user)],
+)
 def get_user_positions_endpoint(user_id: str) -> UserPositionsResponse:
     """Return aggregated positions and earnings for the user."""
 
     return get_user_positions(user_id)
 
 
-@app.post("/users/{user_id}/rebalances", response_model=RebalanceActionResponse)
+@app.post(
+    "/users/{user_id}/rebalances",
+    response_model=RebalanceActionResponse,
+    dependencies=[Depends(verify_user)],
+)
 def post_user_rebalance(user_id: str, payload: RebalanceActionRequest):
     """Record a new rebalance action for the user."""
 
@@ -463,7 +496,11 @@ def post_user_rebalance(user_id: str, payload: RebalanceActionRequest):
     )
 
 
-@app.get("/users/{user_id}/rebalances", response_model=RebalanceListResponse)
+@app.get(
+    "/users/{user_id}/rebalances",
+    response_model=RebalanceListResponse,
+    dependencies=[Depends(verify_user)],
+)
 def get_user_rebalances(user_id: str, skip: int = 0, limit: int = 10):
     """Return paginated rebalance actions for the user."""
 
@@ -471,7 +508,11 @@ def get_user_rebalances(user_id: str, skip: int = 0, limit: int = 10):
     return RebalanceListResponse(total=total, items=records)
 
 
-@app.post("/users/{user_id}/risk-adjustments", response_model=RiskAdjustmentResponse)
+@app.post(
+    "/users/{user_id}/risk-adjustments",
+    response_model=RiskAdjustmentResponse,
+    dependencies=[Depends(verify_user)],
+)
 def post_user_risk_adjustment(user_id: str, payload: RiskAdjustmentRequest):
     """Record a new risk adjustment for the user."""
 
@@ -488,7 +529,11 @@ def post_user_risk_adjustment(user_id: str, payload: RiskAdjustmentRequest):
     )
 
 
-@app.get("/users/{user_id}/risk-adjustments", response_model=RiskAdjustmentListResponse)
+@app.get(
+    "/users/{user_id}/risk-adjustments",
+    response_model=RiskAdjustmentListResponse,
+    dependencies=[Depends(verify_user)],
+)
 def get_user_risk_adjustments(user_id: str, skip: int = 0, limit: int = 10):
     """Return paginated risk adjustment records for the user."""
 
@@ -496,7 +541,10 @@ def get_user_risk_adjustments(user_id: str, skip: int = 0, limit: int = 10):
     return RiskAdjustmentListResponse(total=total, items=records)
 
 
-@app.post("/users/{user_id}/earnings")
+@app.post(
+    "/users/{user_id}/earnings",
+    dependencies=[Depends(verify_user)],
+)
 def post_user_earnings(user_id: str, payload: EarningsRequest) -> Dict[str, float]:
     """Record a user's deposit and return projected earnings."""
     return calculate_total_earning(user_id, payload.pool_id, payload.amount)

--- a/src/apy/auth.py
+++ b/src/apy/auth.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Simple token-based authentication helpers."""
+
+import os
+from typing import Dict
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+security = HTTPBearer()
+
+
+def _load_tokens() -> Dict[str, str]:
+    """Load user tokens from ``API_TOKENS`` env variable.
+
+    The variable should contain comma separated ``user:token`` pairs, e.g.::
+
+        API_TOKENS="alice:alice-token,bob:bob-token"
+    """
+
+    pairs = [item.split(":", 1) for item in os.getenv("API_TOKENS", "").split(",") if ":" in item]
+    return {user: token for user, token in pairs}
+
+
+TOKENS = _load_tokens()
+TOKEN_TO_USER = {token: user for user, token in TOKENS.items()}
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> str:
+    """Return the user_id associated with the provided bearer token."""
+
+    if not credentials:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token")
+    user_id = TOKEN_TO_USER.get(credentials.credentials)
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return user_id
+
+
+def verify_user(user_id: str, current_user: str = Depends(get_current_user)) -> None:
+    """Ensure the authenticated user can only access their own resources."""
+
+    if user_id != current_user:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")


### PR DESCRIPTION
## Summary
- add simple token-based auth module
- secure all `/users/{user_id}` endpoints with `verify_user`
- document how to configure and send auth tokens

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68911bd9234483248575a7e15d29c360