### PR TITLE
Add logging and metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "SQLAlchemy",
     "celery",
     "redis",
+    "prometheus-client",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- log API requests and expose Prometheus counter
- instrument Celery task for pool metrics with logging and metrics
- add service layer logging, error handling, and counters for key events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689121e813e483248406a455f39e0de0