### PR TITLE
Use BaseSettings for configuration

### DIFF
--- a/src/apy/api.py
+++ b/src/apy/api.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, confloat
 from sqlalchemy.orm import Session
 
 from .auth import verify_user
+from .config import settings
 from .database import SessionLocal, PoolMetric, init_db
 from .services import (
     calculate_total_earning,
@@ -29,7 +30,7 @@ from .services import (
 )
 
 
-app = FastAPI(title="Curve APY API")
+app = FastAPI(title=settings.api_title)
 init_db()
 
 logger = logging.getLogger(__name__)

--- a/src/apy/config.py
+++ b/src/apy/config.py
@@ -1,0 +1,13 @@
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    database_url: str = Field("sqlite:///curve.db", env="DATABASE_URL")
+    redis_url: str = Field("redis://localhost:6379/0", env="REDIS_URL")
+    schedule_frequency: int = Field(60 * 60 * 8, env="SCHEDULE_FREQUENCY")
+    api_title: str = Field("Curve APY API", env="API_TITLE")
+
+
+settings = Settings()

--- a/src/apy/database.py
+++ b/src/apy/database.py
@@ -1,13 +1,13 @@
 """Database setup for storing pool metrics."""
 
-import os
 from datetime import datetime
 from sqlalchemy import create_engine, Column, Integer, Float, String, DateTime
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///curve.db")
+from .config import settings
 
-engine = create_engine(DATABASE_URL, future=True)
+
+engine = create_engine(settings.database_url, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 Base = declarative_base()
 

--- a/src/apy/worker.py
+++ b/src/apy/worker.py
@@ -2,17 +2,19 @@
 
 from celery import Celery
 
+from .config import settings
+
+
 celery_app = Celery(
     "apy",
-    broker="redis://localhost:6379/0",
-    backend="redis://localhost:6379/0",
+    broker=settings.redis_url,
+    backend=settings.redis_url,
 )
 
 celery_app.conf.beat_schedule = {
     "fetch-pool-metrics": {
         "task": "apy.tasks.fetch_all_pool_metrics",
-        # every 8 hours
-        "schedule": 60 * 60 * 8,
+        "schedule": settings.schedule_frequency,
     }
 }
 celery_app.conf.timezone = "UTC"


### PR DESCRIPTION
## Summary
- centralize application configuration with Pydantic `BaseSettings`
- wire database, worker, and API to pull settings from environment

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689123a322d48324b8e15599a4f69cc2