### PR TITLE
Add basic pytest setup and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,12 @@ dependencies = [
     "slowapi",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "httpx",
+]
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+testpaths = ["tests"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from apy.api import app
+
+
+def test_get_pool_apy(monkeypatch):
+    now = datetime.utcnow()
+
+    class DummyMetric:
+        def __init__(self):
+            self.apy = 1.0
+            self.bribe = 0.1
+            self.trading_fee = 0.2
+            self.crv_reward = 0.3
+            self.recorded_at = now
+
+    def fake_history(pool_id: str, start=None, end=None):
+        return [DummyMetric()]
+
+    monkeypatch.setattr("apy.api.get_pool_apy_history", fake_history)
+
+    client = TestClient(app)
+    response = client.get("/pools/sample/apy")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pool_id"] == "sample"
+    assert data["current"]["apy"] == 1.0
+    assert len(data["history"]) == 1


### PR DESCRIPTION
## Summary
- add pytest config and test for APY endpoint
- run tests on push and PR via GitHub Actions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689186e0465c83248ef2fdbd8977a5ee